### PR TITLE
(chore) Add compilation flag for debugging

### DIFF
--- a/Hedgehog.pro
+++ b/Hedgehog.pro
@@ -21,6 +21,8 @@ QT += webengine
 
 # Input
 
+QMAKE_CXXFLAGS += -g
+
 SOURCES += src/main.cpp \
            src/highlighter.cpp \
            src/documenthandler.cpp


### PR DESCRIPTION
### Description

This PR adds compilation flags for debugging. This will enables us to debug using gdb or other similar debugging tools.

### How to debug

For instance by launching : 

```bash
gdb file Hedgehog
```

### Screenshots

NA