### PR TITLE
(chore) Fix age update bug when moving to another day and question su…

### DIFF
--- a/qml/Session.qml
+++ b/qml/Session.qml
@@ -57,19 +57,26 @@ QtObject {
         return today.getFullYear() + "-" + (today.getMonth() + 1) + "-" + today.getDate();
     }
 
-   function resetAgedQuestions() {
-        for (var questionId in successfulImplementationsThisMonth) {
-            if (successfulImplementationsThisMonth.hasOwnProperty(questionId)) {
-                var questionData = successfulImplementationsThisMonth[questionId];
+   function resetAgedQuestions(today, lastPerformanceUpdateDate) {
+        if (today != lastPerformanceUpdateDate) {
+            for (var questionId in successfulImplementationsThisMonth) {
+                if (successfulImplementationsThisMonth.hasOwnProperty(questionId)) {
+                    var questionData = successfulImplementationsThisMonth[questionId];
 
-                if (questionData.age >= 5) {
-                    questionData.count = 0;
-                    questionData.age = 0;
+                    if (questionData.count >= 5) {
+                        questionData.age += 1;
 
-                    var index = visitedNumbers.indexOf(questionId);
-                    if (index > -1) {
-                        visitedNumbers.splice(index, 1);
+                        if (questionData.age >= 5) {
+                            questionData.count = 0;
+                            questionData.age = 0;
+
+                            var index = visitedNumbers.indexOf(questionId);
+                            if (index > -1) {
+                                visitedNumbers.splice(index, 1);
+                            }
+                        }
                     }
+                    successfulImplementationsThisMonth[questionId] = questionData;
                 }
             }
         }
@@ -96,7 +103,7 @@ QtObject {
             newPerformanceRating = "Excellent";
         }
 
-        resetAgedQuestions();
+        resetAgedQuestions(today, lastPerformanceUpdateDate);
 
         if (lastPerformanceUpdateDate === today && performanceRating === newPerformanceRating) {
             console.log("Performance rating already updated for today.");
@@ -106,10 +113,6 @@ QtObject {
         performanceRating = newPerformanceRating
 
         lastPerformanceUpdateDate = today;
-
-        if (successfulImplementationsThisMonth[questionId].count >= 5) {
-            successfulImplementationsThisMonth[questionId].age += 1;
-        }
 
         saveSession();
     }


### PR DESCRIPTION
### Description

In current version, the app algorithm doesn't update the age of the question with count >= 5. This causes the question not to be asked to the user, but also not to be rotten after some time, thus blocking the overall dynamic of the application. This change fixes the problem by evaluating the age of the successful question and increasing its age to eventually get rotten over time.

### Test

**Test age increase**

- Made sure there is 1 or multiple elements with count >= 5
- Changed the date to previous day and execute the application.
   - As a result the question with count >= 5 see their age increase by 1

**Test age, count reset**

- Made sure there is 1 element with count >= 5 and age equals 5
- Changed the date to previous day and execute the application.
   - As a result the question with count >= 5 and age equals 5 sees following setting count = 0 and age = 0
   - observed that the question id is cleared from visitedNumbers