### PR TITLE
(chore) create install script in .pro

### DIFF
--- a/Hedgehog.pro
+++ b/Hedgehog.pro
@@ -17,7 +17,7 @@ QT += webengine
 # Please consult the documentation of the deprecated API in order to know
 # how to port your code away from it.
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
-#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 # Input
 
@@ -31,3 +31,22 @@ HEADERS += includes/highlighter.h \
            includes/documenthandler.h 
 
 RESOURCES += resources.qrc
+
+target.path = /Applications/Hedgehog
+resources.path = /Applications/Hedgehog
+INSTALLS += target resources
+
+# MacOS-specific settings
+macx {
+    target.files = Hedgehog.app/Contents/MacOS/$${TARGET}
+    resources.files = target
+}
+
+# Non-macOS platforms fallback
+!macx {
+    target.files = Hedgehog
+    resources.files = target
+}
+
+QMAKE_POST_LINK +=  if [ ! -d /Applications/Hedgehog ]; then mkdir -p /Applications/Hedgehog; fi; \
+                    if [ ! -f /Applications/Hedgehog/sessionData.json ]; then cp $$PWD/sessionData.json /Applications/Hedgehog/; fi

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ brew install qt@5
 You will need Qt installation for your platform to build and launch Hedgehog, after what you can launch below commands which will generate the binary file
 
 ```bash
-qmake && make
+make clean && qmake && make && make install
+cd /Applications/Hedgehog/
+./Hedgehog
 ```
 
 # How to contribute

--- a/qml/StatsPage.qml
+++ b/qml/StatsPage.qml
@@ -158,7 +158,6 @@ Rectangle {
         CustomButton {
             id: startPractice
 
-            enabled: isCategorySelected
             buttonText: "Start Practicing"
             page: practicePage
         }


### PR DESCRIPTION
### Description

⚠️ This code updates the .pro file to install the application inside `/Applications/Hedgehog`
Removing the application is done by just removing `/Applications/Hedgehog` from there.

This commit will fix #55

The usual way to work with the app is :

- To `make install` and work on the binary in /Applications/Hedgehog
- When a change is made, just `make install` again, it will then update the binary only

Cheers!

### Tests

- I tested with clean install
- I tested with already install application and made sure that if the sessionData.json file exists, it's not overwritten by the new install/udpate.