### PR TITLE
(bug) Fix nasty bug blocking practice on next problem

### DIFF
--- a/qml/PracticePage.qml
+++ b/qml/PracticePage.qml
@@ -603,7 +603,7 @@ Rectangle {
 
                         TextArea {
                             id: answerInput
-                            anchors.fill: parent
+                            anchors.fill: backgroundRect
                             readOnly: submitted
                             placeholderText: QuestionsHandler.getQuestionPlaceHolder(questionsData, sessionObject.language, currentQuestionIndex, sessionObject.selectedCategories)
                             font.family: "Courier New"


### PR DESCRIPTION
### Description

Fix nasty bug that happens when trying to solve next practice problem.

The editor was didn't display expected placeholder text, and I couldn't click on the editor after submiting a solution.

Note :
I am still trying to understand the root cause of the problem. 
