### PR TITLE
Tracking how quickly user solves question

### DIFF
--- a/qml/PracticePage.qml
+++ b/qml/PracticePage.qml
@@ -264,7 +264,7 @@ Rectangle {
                         sessionObject.algorithmAttempt(
                             QuestionsHandler.getQuestionID(questionsData, currentQuestionIndex), 
                             true,
-                            timerValue);
+                            timeLimit - timerValue);
                         sessionObject.todayVisitedNumbers += 1;
                     } else {
                         answerInput.text = expectedAnswer;
@@ -277,7 +277,7 @@ Rectangle {
                         sessionObject.algorithmAttempt(
                             QuestionsHandler.getQuestionID(questionsData, currentQuestionIndex), 
                             false,
-                            timerValue);
+                            timeLimit - timerValue);
                     }
 
                     submitted = true

--- a/qml/PracticePage.qml
+++ b/qml/PracticePage.qml
@@ -254,26 +254,30 @@ Rectangle {
                         }
                     }
 
-                    if (result.similarityStatus === "Highly Similar") {
-                        resultsModel.append({ similarity: "Highly Similar", id: currentQuestionIndex + 1 })
-                        correctAnswers++
-                        isCurrentAnswerCorrect = true
-                        sessionObject.algorithmAttempt(QuestionsHandler.getQuestionID(questionsData, currentQuestionIndex), true)
-                        sessionObject.todayVisitedNumbers += 1
-
-                    } else if (result.similarityStatus === "Moderately Similar") {
-                        resultsModel.append({ similarity: "Moderately Similar", id: currentQuestionIndex + 1 })
-                        correctAnswers++
-                        isCurrentAnswerCorrect = true
-                        sessionObject.algorithmAttempt(QuestionsHandler.getQuestionID(questionsData, currentQuestionIndex), true)
-                        sessionObject.todayVisitedNumbers += 1
-
+                    if (result.similarityStatus === "Highly Similar" || result.similarityStatus === "Moderately Similar") {
+                        resultsModel.append({
+                            similarity: result.similarityStatus, 
+                            id: currentQuestionIndex + 1 
+                        });
+                        correctAnswers++;
+                        isCurrentAnswerCorrect = true;
+                        sessionObject.algorithmAttempt(
+                            QuestionsHandler.getQuestionID(questionsData, currentQuestionIndex), 
+                            true,
+                            timerValue);
+                        sessionObject.todayVisitedNumbers += 1;
                     } else {
-                        answerInput.text = expectedAnswer
-                        answerInput.readOnly = true
-                        resultsModel.append({ similarity: "Not Similar", id: currentQuestionIndex + 1 })
-                        isCurrentAnswerCorrect = false
-                        sessionObject.algorithmAttempt(QuestionsHandler.getQuestionID(questionsData, currentQuestionIndex), false)
+                        answerInput.text = expectedAnswer;
+                        answerInput.readOnly = true;
+                        resultsModel.append({
+                            similarity: "Not Similar", 
+                            id: currentQuestionIndex + 1 
+                        });
+                        isCurrentAnswerCorrect = false;
+                        sessionObject.algorithmAttempt(
+                            QuestionsHandler.getQuestionID(questionsData, currentQuestionIndex), 
+                            false,
+                            timerValue);
                     }
 
                     submitted = true

--- a/qml/Session.qml
+++ b/qml/Session.qml
@@ -92,6 +92,25 @@ QtObject {
         return today.getFullYear() + "-" + (today.getMonth() + 1) + "-" + today.getDate();
     }
 
+    function getCurrentDay() {
+        var today = new Date();
+        var daysOfWeek = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+        var dayOfWeek = daysOfWeek[today.getDay()];
+
+        return dayOfWeek
+    }
+
+    function getCurrentTime() {
+        var today = new Date();
+        var hours = today.getHours();
+        var minutes = today.getMinutes();
+
+        hours = hours < 10 ? "0" + hours : hours;
+        minutes = minutes < 10 ? "0" + minutes : minutes;
+
+        return hours + ":" + minutes;
+    }
+
    function resetAgedQuestions(today, lastPerformanceUpdateDate) {
         if (today != lastPerformanceUpdateDate) {
             lastDayVisitedNumbers = todayVisitedNumbers
@@ -155,15 +174,15 @@ QtObject {
         saveSession();
     }
 
-    function algorithmAttempt(questionId, successful, remainingTime) {
+    function algorithmAttempt(questionId, successful, spentTime) {
         if (!successfulImplementations.hasOwnProperty(questionId)) {
             successfulImplementations[questionId] = {
                 count: 0, 
                 age: 0, 
                 streak: 0,
-                remainingTime: {
+                spentTime: {
                     average: 0,
-                    remainTimes: []
+                    spentTimes: []
                 }
             };
         }
@@ -172,12 +191,26 @@ QtObject {
             successfulImplementations[questionId].streak += 1;
             successfulImplementations[questionId].count += 1;
 
-            let currentAverage = successfulImplementations[questionId].remainingTime.average;
+            let currentAverage = successfulImplementations[questionId].spentTime.average;
             let count = successfulImplementations[questionId].count;
-            successfulImplementations[questionId].remainingTime.average = 
-                currentAverage + (remainingTime - currentAverage) / count;
+            successfulImplementations[questionId].spentTime.average = 
+                Number((currentAverage + (spentTime - currentAverage) / count).toFixed(2));
 
-            successfulImplementations[questionId].remainingTime.remainTimes.push(remainingTime);
+            let day = getCurrentDay();
+            var today = getCurrentDate();
+            let currentTime = getCurrentTime();
+
+            let dayEntry = successfulImplementations[questionId].spentTime.spentTimes.find(entry => entry.day === day);
+
+            if (dayEntry) {
+                dayEntry.times.push({ time: currentTime, spentTime: spentTime });
+            } else {
+                successfulImplementations[questionId].spentTime.spentTimes.push({
+                    day: day,
+                    today: today,
+                    times: [{ time: currentTime, spentTime: spentTime }]
+                });
+            }
         } else {
             successfulImplementations[questionId].streak = 0;
         }

--- a/qml/Session.qml
+++ b/qml/Session.qml
@@ -155,14 +155,29 @@ QtObject {
         saveSession();
     }
 
-    function algorithmAttempt(questionId, successful) {
+    function algorithmAttempt(questionId, successful, remainingTime) {
         if (!successfulImplementations.hasOwnProperty(questionId)) {
-            successfulImplementations[questionId] = { count: 0, age: 0, streak: 0 };
+            successfulImplementations[questionId] = {
+                count: 0, 
+                age: 0, 
+                streak: 0,
+                remainingTime: {
+                    average: 0,
+                    remainTimes: []
+                }
+            };
         }
 
         if (successful) {
             successfulImplementations[questionId].streak += 1;
             successfulImplementations[questionId].count += 1;
+
+            let currentAverage = successfulImplementations[questionId].remainingTime.average;
+            let count = successfulImplementations[questionId].count;
+            successfulImplementations[questionId].remainingTime.average = 
+                currentAverage + (remainingTime - currentAverage) / count;
+
+            successfulImplementations[questionId].remainingTime.remainTimes.push(remainingTime);
         } else {
             successfulImplementations[questionId].streak = 0;
         }

--- a/qml/StatsPage.qml
+++ b/qml/StatsPage.qml
@@ -116,8 +116,14 @@ Rectangle {
         }
 
         function getCurrentTime() {
-            var date = new Date();
-            return date.toLocaleString(); // e.g., "10/31/2024, 3:45 PM"
+            var today = new Date();
+            var hours = today.getHours();
+            var minutes = today.getMinutes();
+
+            hours = hours < 10 ? "0" + hours : hours;
+            minutes = minutes < 10 ? "0" + minutes : minutes;
+
+            return hours + ":" + minutes;
         }
     }
 
@@ -283,7 +289,7 @@ Rectangle {
 
         Text {
             id: updatedTime
-            text: "Last updated: " + statsPage.lastUpdateTime
+            text: "Updated today at " + statsPage.lastUpdateTime
             font.pixelSize: 12
             color: themeObject.textColor
             anchors.bottom: parent.bottom


### PR DESCRIPTION
### Description

update the sessionData format to be more data friendly for data visualization
The new format looks like the following for example for 2 different questions with different resolution times : 

```bash
...
        "dfs rec.": {
            "count": 1,
            "age": 0,
            "streak": 1,
            "spentTime": {
                "average": 1,
                "spentTimes": [
                    {
                        "day": "Friday",
                        "today": "2024-11-8",
                        "times": [
                            {
                                "time": "14:08",
                                "spentTime": 1
                            }
                        ]
                    }
                ]
            }
        },
        "bfs it.": {
            "count": 3,
            "age": 0,
            "streak": 3,
            "spentTime": {
                "average": 1.33,
                "spentTimes": [
                    {
                        "day": "Friday",
                        "today": "2024-11-8",
                        "times": [
                            {
                                "time": "14:08",
                                "spentTime": 2
                            },
                            {
                                "time": "14:08",
                                "spentTime": 1
                            },
                            {
                                "time": "14:08",
                                "spentTime": 1
                            }
                        ]
                    }
                ]
            }
        }
    },
...
```

### Data change notice

This is breaking change for the sessionData.json file.
The break will happen when the question is updated.