### PR TITLE
(chore) Improve stats bars display by leaving enough space above the highest bar

### DIFF
--- a/qml/StatsPage.qml
+++ b/qml/StatsPage.qml
@@ -365,8 +365,8 @@ Rectangle {
                 }
             }
 
-            var yAxisMax = Math.ceil(maxTime / 10) * 10;
-            if (yAxisMax === 0) yAxisMax = 10;
+            var yAxisMax = Math.ceil(maxTime / 10) * 10 * 2;
+            if (yAxisMax === 0) yAxisMax = 20;
 
             // Draw the axes
             ctx.beginPath();


### PR DESCRIPTION
### Description

Increase the high above the bar with the highest value to have a better looking graph.
