### PR TITLE
(chore) detailed view for the question resolution time

### DIFF
--- a/logic/topological-sorting/topological-sorting.js
+++ b/logic/topological-sorting/topological-sorting.js
@@ -19,7 +19,7 @@ var question = [
 }
 
 void topoSortGraph(vector<int> nodes, vector<int> graph[], int V) {
-    map<int, bool> visited(V, false);
+    map<int, bool> visited;
     stack<int> stk;
     
     for (int node : nodes) {

--- a/qml/PracticePage.qml
+++ b/qml/PracticePage.qml
@@ -947,9 +947,6 @@ Rectangle {
                         enabled: submitted
                         radius: 10
                         visible: !quizComplete
-                        // anchors.top: parent.top
-                        // anchors.right: parent.right
-                        // anchors.margins: 10
 
                         Text {
                             id: viewSubmissionText


### PR DESCRIPTION
### Description

This PR brings quite a few changes to the Stats page. It contains update to have the 
- detail view for the question resolution time
- a new button to switch between the different views
- a new canvas to accomplish the same

**Note**

The detailed view might require some more fine tuning for the colors used since some colors can have too few contrast to be differentiated between them.

### Tests

<img width="1212" alt="Screenshot 2024-11-10 at 9 40 45 PM" src="https://github.com/user-attachments/assets/8cdf0e8f-12d9-47ee-b937-2128e227f472">

<img width="1212" alt="Screenshot 2024-11-10 at 9 40 58 PM" src="https://github.com/user-attachments/assets/8a24ad84-be1d-4503-ae65-2b92c293af19">

<img width="1212" alt="Screenshot 2024-11-10 at 9 41 15 PM" src="https://github.com/user-attachments/assets/0e3109bd-4358-4d1b-80a4-df3f213b31c2">
